### PR TITLE
Fix latest branch not detected

### DIFF
--- a/portsfetch
+++ b/portsfetch
@@ -63,7 +63,7 @@ else # Update the existing repo. -- cwells
 	git -C "${DESTDIR}" pull --ff-only
 fi
 
-BRANCH=$(git -C "${DESTDIR}" branch --list -r | grep -E '^\s*origin/20[0-9]{2}Q[1-4]$' | sort | tail -1 | sed 's/ *origin\///')
+BRANCH=$(git -C "${DESTDIR}" branch --list -r | grep -E '^[[:space:]]*origin/20[0-9]{2}Q[1-4]$' | sort | tail -1 | sed 's/ *origin\///')
 if [ "${#BRANCH}" != "6" ]; then
 	echo 'Failed to determine the correct branch to use.'
 	exit 1


### PR DESCRIPTION
grep extended regular expression (ERE) does not support '\s'
for whitespace character class (unlike PCRE), confusingly though
it works at some version of grep (e.g. GNU grep 3.4) This
undocumented feature fails on (grep 2.5.1-FreeBSD), the
re_format(7) provided character class works on all.